### PR TITLE
[Hotfix]: Fix old go.mod package declaration to match proj name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 A library for parsing US Phone Numbers & validating area codes against the existing list of Area Codes from [Wikipedia](https://en.wikipedia.org/wiki/List_of_North_American_Numbering_Plan_area_codes#Assignment_actions_by_year).
 
+## Implementing
+To use this library in your project
+```
+go get github.com/z-cran/usphonenumbers
+```
+
+To use a specific tag of this library in your project
+```
+go get github.com/z-cran/usphonenumbers@<tag>
+```
+
+
 ## Contributing
 
 Feel free to contribute through the following steps:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/z-cran/phonenumbers
+module github.com/z-cran/usphonenumbers
 
 go 1.18
 


### PR DESCRIPTION
- From `phonenumbers` to `usphonenumbers`
- Update readme to include `go get` instructions